### PR TITLE
Minor changes to reflect new name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     meetupanator (0.2)
-      thor (~> 0.19.1)
+      thor (~> 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -92,13 +92,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fakefs (~> 0.6.5)
-  guard (~> 2.12.1)
-  guard-rspec (~> 4.5.0)
+  fakefs (~> 0.6)
+  guard (~> 2.12)
+  guard-rspec (~> 4.5)
   meetupanator!
-  pry (~> 0.10.1)
-  rake (~> 10.4.2)
-  rspec (~> 3.2.0)
-  rubocop (~> 0.29.1)
-  vcr (~> 2.9.3)
-  webmock (~> 1.20.4)
+  pry (~> 0.10)
+  rake (~> 10.4)
+  rspec (~> 3.2)
+  rubocop (~> 0.29)
+  vcr (~> 2.9)
+  webmock (~> 1.20)

--- a/meetupanator.gemspec
+++ b/meetupanator.gemspec
@@ -12,19 +12,19 @@ Gem::Specification.new do |s|
   s.authors = ["Joe Sustaric", "John Fulton", "Charles Korn"]
   s.files = Dir['lib/   *.rb'] + Dir['bin/*'] + ['README.md']
   s.test_files = Dir['spec/*']
-  s.homepage = 'https://github.com/joesustaric/meetup-thingy'
+  s.homepage = 'https://github.com/joesustaric/meetupanator'
   # s.license       = '???'
   s.executables = ['meetupanator']
 
-  s.add_development_dependency 'rspec', '~> 3.2.0'
-  s.add_development_dependency 'pry', '~> 0.10.1'
-  s.add_development_dependency 'guard-rspec', '~> 4.5.0'
-  s.add_development_dependency 'webmock', '~> 1.20.4'
-  s.add_development_dependency 'fakefs', '~> 0.6.5'
-  s.add_development_dependency 'vcr', '~> 2.9.3'
-  s.add_development_dependency 'rubocop', '~> 0.29.1'
-  s.add_development_dependency 'guard', '~> 2.12.1'
-  s.add_development_dependency 'rake', '~> 10.4.2'
-  s.add_runtime_dependency 'thor', '~> 0.19.1'
+  s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'pry', '~> 0.10'
+  s.add_development_dependency 'guard-rspec', '~> 4.5'
+  s.add_development_dependency 'webmock', '~> 1.20'
+  s.add_development_dependency 'fakefs', '~> 0.6'
+  s.add_development_dependency 'vcr', '~> 2.9'
+  s.add_development_dependency 'rubocop', '~> 0.29'
+  s.add_development_dependency 'guard', '~> 2.12'
+  s.add_development_dependency 'rake', '~> 10.4'
+  s.add_runtime_dependency 'thor', '~> 0.19'
 end
 


### PR DESCRIPTION
Rename gemspec to match new name. 
Update gem homepage URL. 
Be less restrictive with dependencies to resolve build warnings.